### PR TITLE
Fix Player issues on the lobby screen

### DIFF
--- a/src/socket/ClientMessageReceiver.java
+++ b/src/socket/ClientMessageReceiver.java
@@ -148,7 +148,6 @@ public class ClientMessageReceiver extends MessageReceiver
 		if(msg.getType() == Action.PLAYER_JOIN)
 		{
 			Player player = new Player(msg.getName(), msg.getPlayerId());
-			PlayerManager.addNewPlayer(player);
 			System.out.println("[NEW PLAYER]: Total Player Count: " + PlayerManager.playerCount());
 		}
 		else if(msg.getType() == Action.INIT)

--- a/src/utils/PlayerManager.java
+++ b/src/utils/PlayerManager.java
@@ -1,5 +1,4 @@
 package utils;
-
 import java.util.ArrayList;
 
 import messages.PlayerStatusMessage;
@@ -17,7 +16,6 @@ public class PlayerManager
     private static volatile PlayerManager instance = null;
     private static volatile ArrayList<Player> playerList = null;
     private static volatile Player player = null;
-
 	
     /**
      * Private PlayerManager constructor.
@@ -93,7 +91,6 @@ public class PlayerManager
     	}
     }
 
-
 	public static Player getPlayer() 
 	{
 		return player;
@@ -101,13 +98,14 @@ public class PlayerManager
 	
 	public static void setPlayer(Player obj)
 	{
-		player = obj;
+		player = obj;                
 	}
 	
 	public synchronized static void addNewPlayer(Player player)
-	{
-		playerList.add(player);
-		System.out.println("New Player: " + player);
+	{       
+                //sort the list by ID
+		playerList.add(player);               
+		System.out.println("New Player: " + player);          
 	}
 	
 	public synchronized static void removePlayer(Player player)
@@ -117,14 +115,23 @@ public class PlayerManager
 	
 	public static int playerCount()
 	{
-		return playerList.size() + 1;
+                System.out.println(playerList);
+		return playerList.size() + 2;
+                
 	}
 	
 	public synchronized static Player getOtherPlayer(int playerId)
 	{
-		return playerList.get(playerId);
+                for (Player currentPlayer : playerList)
+                {
+                    if (currentPlayer.getPlayerId() == playerId)
+                    {
+                        return currentPlayer;
+                    }
+                }
+                //Player not found, return Null
+                return null;
 	}
-        
 }
 
 


### PR DESCRIPTION
Fixed the issues with Player manager where players were being counted twice. Also updated a Player Manager method so that it always grabbed the right player using the ID.

Deleted line 151 from clientMessageReceiver

Line 116+ in PlayerManager - Updated player count and getOtherPlayer Methods